### PR TITLE
Fixed string parsing in server filter

### DIFF
--- a/code/serverbrowsing/filter/CToken.cpp
+++ b/code/serverbrowsing/filter/CToken.cpp
@@ -31,12 +31,12 @@ CToken::~CToken() {
 std::string readString(const char *filter, int &idx, int len) {
 	std::string str = "";
 	int i;
-	for(i=idx;i<len;i++) {
-		if(filter[i] == '\'' || filter[i] == '"') break;
+	char delim = filter[idx];
+	for(i=idx+1;i<len;i++) {
+		if(filter[i] == delim) break;
 		str += filter[i];
 	}
 	idx = i;
-	if(filter[i] == '\'' || filter[i] == '"') idx++; //skip the " or '
 	return str;
 }
 const char *readVariable(const char *filter, int &idx, int len) {
@@ -232,7 +232,7 @@ std::vector<CToken> CToken::filterToTokenList(const char *filter) {
 			tokens.push_back(token);
 		} else if(filter[i] == '\'' || filter[i] == '"') {
 			//gets freed in token deconstructor
-			std::string str = readString(filter, ++i, filterlen);
+			std::string str = readString(filter, i, filterlen);
 			token = CToken(str);
 			tokens.push_back(token);
 		} else if(filter[i] =='-') {


### PR DESCRIPTION
This fixes a bug in server filter parser where if a string token is not followed by a whitespace or end of string, the first character of the next token would get eaten. Bug affects FlatOut 2 (example string below) and likely more games.
```
numplayers < maxplayers and gamever='FO14' and datachecksum='3546d58093237eb33b2a96bb813370d846ffcec8' and password=0 and (gamemode='openwaiting' or gamemode='openplaying') and gametype='stunt'
```
Closes https://github.com/chc/openspy-core-v2/issues/7.
Thanks to CodaHighland for assistance with tracking this down.